### PR TITLE
Add implmentation of logical replication message formats

### DIFF
--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -101,6 +101,11 @@ func main() {
 					log.Fatalln("ParseXLogData failed:", err)
 				}
 				log.Println("XLogData =>", "WALStart", xld.WALStart, "ServerWALEnd", xld.ServerWALEnd, "ServerTime:", xld.ServerTime, "WALData", string(xld.WALData))
+				logicalMsg, err := pglogrepl.Parse(xld.WALData)
+				if err != nil {
+					log.Fatalf("Parse logical replication message: %s", err)
+				}
+				log.Printf("Receive a logical replication message: %s", logicalMsg.Type())
 
 				clientXLogPos = xld.WALStart + pglogrepl.LSN(len(xld.WALData))
 			}

--- a/message.go
+++ b/message.go
@@ -1,0 +1,636 @@
+package pglogrepl
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// MessageType indicates type of a logical replication message.
+type MessageType uint8
+
+func (t MessageType) String() string {
+	switch t {
+	case MessageTypeBegin:
+		return "Begin"
+	case MessageTypeCommit:
+		return "Commit"
+	case MessageTypeOrigin:
+		return "Origin"
+	case MessageTypeRelation:
+		return "Relation"
+	case MessageTypeType:
+		return "Type"
+	case MessageTypeInsert:
+		return "Insert"
+	case MessageTypeUpdate:
+		return "Update"
+	case MessageTypeDelete:
+		return "Delete"
+	case MessageTypeTruncate:
+		return "Truncate"
+	default:
+		return "Unknown"
+	}
+}
+
+// List of types of logical replication messages.
+const (
+	MessageTypeBegin    MessageType = 'B'
+	MessageTypeCommit               = 'C'
+	MessageTypeOrigin               = 'O'
+	MessageTypeRelation             = 'R'
+	MessageTypeType                 = 'Y'
+	MessageTypeInsert               = 'I'
+	MessageTypeUpdate               = 'U'
+	MessageTypeDelete               = 'D'
+	MessageTypeTruncate             = 'T'
+)
+
+// Message is a message received from server.
+type Message interface {
+	Type() MessageType
+}
+
+// MessageDecoder decodes meessage into struct.
+type MessageDecoder interface {
+	Decode([]byte) error
+}
+
+type baseMessage struct {
+	msgType MessageType
+}
+
+// Type returns message type.
+func (m *baseMessage) Type() MessageType {
+	return m.msgType
+}
+
+// Decode parse src into message struct. The src must contain the complete message starts after
+// the first message type byte.
+func (m *baseMessage) Decode(src []byte) error {
+	return fmt.Errorf("message decode not implemented")
+}
+
+func (m *baseMessage) lengthError(name string, expectedLen, actualLen int) error {
+	return fmt.Errorf("%s must have %d bytes, got %d bytes", name, expectedLen, actualLen)
+}
+
+func (m *baseMessage) decodeStringError(name, field string) error {
+	return fmt.Errorf("%s.%s decode string error", name, field)
+}
+
+func (m *baseMessage) decodeTupleDataError(name, field string, e error) error {
+	return fmt.Errorf("%s.%s decode tuple error: %s", name, field, e.Error())
+}
+
+func (m *baseMessage) invalidTupleTypeError(name, field string, e string, a byte) error {
+	return fmt.Errorf("%s.%s invalid tuple type value, expect %s, actual %c", name, field, e, a)
+}
+
+// decodeString decode a string from src and returns the length of bytes being parsed.
+//
+// String type definition: https://www.postgresql.org/docs/current/protocol-message-types.html
+// String(s)
+//   A null-terminated string (C-style string). There is no specific length limitation on strings.
+//   If s is specified it is the exact value that will appear, otherwise the value is variable.
+//   Eg. String, String("user").
+//
+// If there is no null byte in src, return -1.
+func (m *baseMessage) decodeString(src []byte) (string, int) {
+	end := bytes.IndexByte(src, byte(0))
+	if end == -1 {
+		return "", -1
+	}
+	// Trim the last null byte before converting it to a Golang string, then we can
+	// compare the result string with a Golang string literal.
+	return string(src[:end]), end + 1
+}
+
+func (m *baseMessage) decodeLSN(src []byte) (LSN, int) {
+	return LSN(binary.BigEndian.Uint64(src)), 8
+}
+
+func (m *baseMessage) decodeTime(src []byte) (time.Time, int) {
+	return pgTimeToTime(int64(binary.BigEndian.Uint64(src))), 8
+}
+
+func (m *baseMessage) decodeUint16(src []byte) (uint16, int) {
+	return binary.BigEndian.Uint16(src), 2
+}
+
+func (m *baseMessage) decodeUint32(src []byte) (uint32, int) {
+	return binary.BigEndian.Uint32(src), 4
+}
+
+func (m *baseMessage) decodeUint64(src []byte) (uint64, int) {
+	return binary.BigEndian.Uint64(src), 8
+}
+
+// BeginMessage is a begin message.
+type BeginMessage struct {
+	baseMessage
+	//FinalLSN is the final LSN of the transaction.
+	FinalLSN LSN
+	// CommitTime is the commit timestamp of the transaction.
+	CommitTime time.Time
+	// Xid of the transaction.
+	Xid uint32
+}
+
+// Decode decodes the message from src.
+func (m *BeginMessage) Decode(src []byte) error {
+	if len(src) < 20 {
+		return m.lengthError("BeginMessage", 20, len(src))
+	}
+	var low, used int
+	m.FinalLSN, used = m.decodeLSN(src)
+	low += used
+	m.CommitTime, used = m.decodeTime(src[low:])
+	low += used
+	m.Xid = binary.BigEndian.Uint32(src[low:])
+
+	m.msgType = MessageTypeBegin
+
+	return nil
+}
+
+// CommitMessage is a commit message.
+type CommitMessage struct {
+	baseMessage
+	// Flags currently unused (must be 0).
+	Flags uint8
+	// CommitLSN is the LSN of the commit.
+	CommitLSN LSN
+	// TransactionEndLSN is the end LSN of the transaction.
+	TransactionEndLSN LSN
+	// CommitTime is the commit timestamp of the transaction
+	CommitTime time.Time
+}
+
+// Decode decodes the message from src.
+func (m *CommitMessage) Decode(src []byte) error {
+	if len(src) < 25 {
+		return m.lengthError("CommitMessage", 25, len(src))
+	}
+	var low, used int
+	m.Flags = src[0]
+	low += 1
+	m.CommitLSN, used = m.decodeLSN(src[low:])
+	low += used
+	m.TransactionEndLSN, used = m.decodeLSN(src[low:])
+	low += used
+	m.CommitTime, _ = m.decodeTime(src[low:])
+
+	m.msgType = MessageTypeCommit
+
+	return nil
+}
+
+// OriginMessage is a origin message.
+type OriginMessage struct {
+	baseMessage
+	// CommitLSN is the LSN of the commit on the origin server.
+	CommitLSN LSN
+	Name      string
+}
+
+// Decode decodes to message from src.
+func (m *OriginMessage) Decode(src []byte) error {
+	if len(src) < 8 {
+		return m.lengthError("OriginMessage", 9, len(src))
+	}
+
+	var low, used int
+	m.CommitLSN, used = m.decodeLSN(src)
+	low += used
+	m.Name, used = m.decodeString(src[low:])
+	if used < 0 {
+		return m.decodeStringError("OriginMessage", "Name")
+	}
+
+	m.msgType = MessageTypeOrigin
+
+	return nil
+}
+
+// RelationMessageColumn is one column in a RelationMessage.
+type RelationMessageColumn struct {
+	// Flags for the column. Currently can be either 0 for no flags or 1 which marks the column as part of the key.
+	Flags uint8
+
+	Name string
+
+	// DataType is the ID of the column's data type.
+	DataType uint32
+
+	// TypeModifier is type modifier of the column (atttypmod).
+	TypeModifier uint32
+}
+
+// RelationMessage is a relation message.
+type RelationMessage struct {
+	baseMessage
+	RelationID      uint32
+	Namespace       string
+	RelationName    string
+	ReplicaIdentity uint8
+	ColumnNum       uint16
+	Columns         []*RelationMessageColumn
+}
+
+// Decode decodes to message from src.
+func (m *RelationMessage) Decode(src []byte) error {
+	if len(src) < 7 {
+		return m.lengthError("RelationMessage", 7, len(src))
+	}
+
+	var low, used int
+	m.RelationID, used = m.decodeUint32(src)
+	low += used
+
+	m.Namespace, used = m.decodeString(src[low:])
+	if used < 0 {
+		return m.decodeStringError("RelationMessage", "Namespace")
+	}
+	low += used
+
+	m.RelationName, used = m.decodeString(src[low:])
+	if used < 0 {
+		return m.decodeStringError("RelationMessage", "RelationName")
+	}
+	low += used
+
+	m.ReplicaIdentity = uint8(src[low])
+	low++
+
+	m.ColumnNum, used = m.decodeUint16(src[low:])
+	low += used
+
+	for i := 0; i < int(m.ColumnNum); i++ {
+		column := new(RelationMessageColumn)
+		column.Flags = uint8(src[low])
+		low++
+		column.Name, used = m.decodeString(src[low:])
+		if used < 0 {
+			return m.decodeStringError("RelationMessage", fmt.Sprintf("Column[%d].Name", i))
+		}
+		low += used
+
+		column.DataType, used = m.decodeUint32(src[low:])
+		low += used
+
+		column.TypeModifier, used = m.decodeUint32(src[low:])
+		low += used
+
+		m.Columns = append(m.Columns, column)
+	}
+
+	m.msgType = MessageTypeRelation
+
+	return nil
+}
+
+// TypeMessage is a type message.
+type TypeMessage struct {
+	baseMessage
+	DataType  uint32
+	Namespace string
+	Name      string
+}
+
+// Decode decodes to message from src.
+func (m *TypeMessage) Decode(src []byte) error {
+	if len(src) < 6 {
+		return m.lengthError("TypeMessage", 6, len(src))
+	}
+
+	var low, used int
+	m.DataType, used = m.decodeUint32(src)
+	low += used
+
+	m.Namespace, used = m.decodeString(src[low:])
+	if used < 0 {
+		return m.decodeStringError("TypeMessage", "Namespace")
+	}
+	low += used
+
+	m.Name, used = m.decodeString(src[low:])
+	if used < 0 {
+		return m.decodeStringError("TypeMessage", "Name")
+	}
+
+	m.msgType = MessageTypeType
+
+	return nil
+}
+
+// List of types of data in a tuple.
+const (
+	TupleDataTypeNull  = uint8('n')
+	TupleDataTypeToast = uint8('u')
+	TupleDataTypeText  = uint8('t')
+)
+
+// TupleDataColumn is a column in a TupleData.
+type TupleDataColumn struct {
+	// DataType indicates the how does the data is stored.
+	//	 Byte1('n') Identifies the data as NULL value.
+	//	 Or
+	//	 Byte1('u') Identifies unchanged TOASTed value (the actual value is not sent).
+	//	 Or
+	//	 Byte1('t') Identifies the data as text formatted value.
+	DataType uint8
+	Length   uint32
+	// Data is th value of the column, in text format. (A future release might support additional formats.) n is the above length.
+	Data []byte
+}
+
+// Int64 parse column data as an int64 integer.
+func (c *TupleDataColumn) Int64() (int64, error) {
+	if c.DataType != TupleDataTypeText {
+		return 0, fmt.Errorf("invalid column's data type, expect %c, actual %c",
+			TupleDataTypeText, c.DataType)
+	}
+
+	return strconv.ParseInt(string(c.Data), 10, 64)
+}
+
+// TupleData contains row change information.
+type TupleData struct {
+	baseMessage
+	ColumnNum uint16
+	Columns   []*TupleDataColumn
+}
+
+// Decode decodes to message from src.
+func (m *TupleData) Decode(src []byte) (int, error) {
+	var low, used int
+
+	m.ColumnNum, used = m.decodeUint16(src)
+	low += used
+
+	for i := 0; i < int(m.ColumnNum); i++ {
+		column := new(TupleDataColumn)
+		column.DataType = uint8(src[low])
+		low += 1
+
+		switch column.DataType {
+		case TupleDataTypeText:
+			column.Length, used = m.decodeUint32(src[low:])
+			low += used
+
+			column.Data = make([]byte, int(column.Length))
+			for j := 0; j < int(column.Length); j++ {
+				column.Data[j] = src[low+j]
+			}
+			low += int(column.Length)
+		case TupleDataTypeNull, TupleDataTypeToast:
+		}
+
+		m.Columns = append(m.Columns, column)
+	}
+
+	return low + 1, nil
+}
+
+// InsertMessage is a insert message
+type InsertMessage struct {
+	baseMessage
+	// RelationID is the ID of the relation corresponding to the ID in the relation message.
+	RelationID uint32
+	Tuple      *TupleData
+}
+
+// Decode decodes to message from src.
+func (m *InsertMessage) Decode(src []byte) error {
+	if len(src) < 8 {
+		return m.lengthError("InsertMessage", 8, len(src))
+	}
+
+	var low, used int
+
+	m.RelationID, used = m.decodeUint32(src)
+	low += used
+
+	tupleType := uint8(src[low])
+	low += 1
+	if tupleType != 'N' {
+		return m.invalidTupleTypeError("InsertMessage", "TupleType", "N", tupleType)
+	}
+
+	m.Tuple = new(TupleData)
+	_, err := m.Tuple.Decode(src[low:])
+	if err != nil {
+		return m.decodeTupleDataError("InsertMessage", "TupleData", err)
+	}
+
+	m.msgType = MessageTypeInsert
+
+	return nil
+}
+
+// List of types of UpdateMessage tuples.
+const (
+	UpdateMessageTupleTypeNone = uint8(0)
+	UpdateMessageTupleTypeKey  = uint8('K')
+	UpdateMessageTupleTypeOld  = uint8('O')
+	UpdateMessageTupleTypeNew  = uint8('N')
+)
+
+// UpdateMessage is a update message.
+type UpdateMessage struct {
+	baseMessage
+	RelationID uint32
+
+	// OldTupleType
+	//   Byte1('K'):
+	//     Identifies the following TupleData submessage as a key.
+	//     This field is optional and is only present if the update changed data
+	//     in any of the column(s) that are part of the REPLICA IDENTITY index.
+	//
+	//   Byte1('O'):
+	//     Identifies the following TupleData submessage as an old tuple.
+	//     This field is optional and is only present if table in which the update happened
+	//     has REPLICA IDENTITY set to FULL.
+	//
+	//   The Update message may contain either a 'K' message part or an 'O' message part
+	//   or neither of them, but never both of them.
+	OldTupleType uint8
+	OldTuple     *TupleData
+
+	// NewTuple is the contents of a new tuple.
+	//   Byte1('N'): Identifies the following TupleData message as a new tuple.
+	NewTuple *TupleData
+}
+
+// Decode decodes to message from src.
+func (m *UpdateMessage) Decode(src []byte) (err error) {
+	if len(src) < 6 {
+		return m.lengthError("UpdateMessage", 6, len(src))
+	}
+
+	var low, used int
+
+	m.RelationID, used = m.decodeUint32(src)
+	low += used
+
+	tupleType := uint8(src[low])
+	low++
+
+	switch tupleType {
+	case UpdateMessageTupleTypeKey, UpdateMessageTupleTypeOld:
+		m.OldTupleType = tupleType
+		m.OldTuple = new(TupleData)
+		used, err = m.OldTuple.Decode(src[low:])
+		if err != nil {
+			return m.decodeTupleDataError("UpdateMessage", "OldTuple", err)
+		}
+		low += used
+		tupleType = uint8(src[low])
+		low++
+		fallthrough
+	case UpdateMessageTupleTypeNew:
+		m.NewTuple = new(TupleData)
+		_, err = m.NewTuple.Decode(src[low:])
+		if err != nil {
+			return m.decodeTupleDataError("UpdateMessage", "NewTuple", err)
+		}
+	default:
+		return m.invalidTupleTypeError("UpdateMessage", "Tuple", "K/O/N", tupleType)
+	}
+
+	m.msgType = MessageTypeUpdate
+
+	return nil
+}
+
+// List of types of DeleteMessage tuples.
+const (
+	DeleteMessageTupleTypeKey = uint8('K')
+	DeleteMessageTupleTypeOld = uint8('O')
+)
+
+// DeleteMessage is a delete message.
+type DeleteMessage struct {
+	baseMessage
+	RelationID uint32
+	// OldTupleType
+	//   Byte1('K'):
+	//     Identifies the following TupleData submessage as a key.
+	//     This field is present if the table in which the delete has happened uses an index
+	//     as REPLICA IDENTITY.
+	//
+	//   Byte1('O')
+	//     Identifies the following TupleData message as a old tuple.
+	//     This field is present if the table in which the delete has happened has
+	//     REPLICA IDENTITY set to FULL.
+	//
+	// The Delete message may contain either a 'K' message part or an 'O' message part,
+	// but never both of them.
+	OldTupleType uint8
+	OldTuple     *TupleData
+}
+
+// Decode decodes a message from src.
+func (m *DeleteMessage) Decode(src []byte) (err error) {
+	if len(src) < 4 {
+		return m.lengthError("DeleteMessage", 4, len(src))
+	}
+
+	var low, used int
+
+	m.RelationID, used = m.decodeUint32(src)
+	low += used
+
+	m.OldTupleType = uint8(src[low])
+	low++
+
+	switch m.OldTupleType {
+	case DeleteMessageTupleTypeKey, DeleteMessageTupleTypeOld:
+		m.OldTuple = new(TupleData)
+		_, err = m.OldTuple.Decode(src[low:])
+		if err != nil {
+			return m.decodeTupleDataError("DeleteMessage", "OldTuple", err)
+		}
+	default:
+		return m.invalidTupleTypeError("DeleteMessage", "OldTupleType", "K/O", m.OldTupleType)
+	}
+
+	m.msgType = MessageTypeDelete
+
+	return nil
+}
+
+// List of truncate options.
+const (
+	TruncateOptionCascade = uint8(1) << iota
+	TruncateOptionRestartIdentity
+)
+
+// TruncateMessage is a truncate message.
+type TruncateMessage struct {
+	baseMessage
+	RelationNum uint32
+	Option      uint8
+	RelationIDs []uint32
+}
+
+// Decode decodes to message from src.
+func (m *TruncateMessage) Decode(src []byte) (err error) {
+	if len(src) < 9 {
+		return m.lengthError("TruncateMessage", 9, len(src))
+	}
+
+	var low, used int
+	m.RelationNum, used = m.decodeUint32(src)
+	low += used
+
+	m.Option = uint8(src[low])
+	low++
+
+	m.RelationIDs = make([]uint32, m.RelationNum)
+	for i := 0; i < int(m.RelationNum); i++ {
+		m.RelationIDs[i], used = m.decodeUint32(src[low:])
+		low += used
+	}
+
+	m.msgType = MessageTypeTruncate
+
+	return nil
+}
+
+// Parse parse a logical replicaton message.
+func Parse(data []byte) (m Message, err error) {
+	var decoder MessageDecoder
+	msgType := MessageType(data[0])
+	switch msgType {
+	case MessageTypeBegin:
+		decoder = new(BeginMessage)
+	case MessageTypeCommit:
+		decoder = new(CommitMessage)
+	case MessageTypeOrigin:
+		decoder = new(OriginMessage)
+	case MessageTypeRelation:
+		decoder = new(RelationMessage)
+	case MessageTypeType:
+		decoder = new(TypeMessage)
+	case MessageTypeInsert:
+		decoder = new(InsertMessage)
+	case MessageTypeUpdate:
+		decoder = new(UpdateMessage)
+	case MessageTypeDelete:
+		decoder = new(DeleteMessage)
+	case MessageTypeTruncate:
+		decoder = new(TruncateMessage)
+	}
+	if decoder != nil {
+		if err = decoder.Decode(data[1:]); err != nil {
+			return nil, err
+		}
+	}
+
+	return decoder.(Message), nil
+}

--- a/message.go
+++ b/message.go
@@ -393,7 +393,7 @@ func (m *TupleData) Decode(src []byte) (int, error) {
 		m.Columns = append(m.Columns, column)
 	}
 
-	return low + 1, nil
+	return low, nil
 }
 
 // InsertMessage is a insert message

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,280 @@
+package pglogrepl
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var bigEndian = binary.BigEndian
+
+type messageSuite struct {
+	suite.Suite
+}
+
+func (s *messageSuite) R() *require.Assertions {
+	return s.Require()
+}
+
+func (s *messageSuite) Equal(e, a interface{}, args ...interface{}) {
+	s.R().Equal(e, a, args...)
+}
+
+func (s *messageSuite) NoError(err error) {
+	s.R().NoError(err)
+}
+
+func (s *messageSuite) True(value bool) {
+	s.R().True(value)
+}
+
+func (s *messageSuite) newLSN() LSN {
+	return LSN(rand.Int63())
+}
+
+func (s *messageSuite) newXid() uint32 {
+	return uint32(rand.Int31())
+}
+
+func (s *messageSuite) newTime() (time.Time, uint64) {
+	// Postgres time format only support millisecond accuracy.
+	now := time.Now().Truncate(time.Millisecond)
+	return now, uint64(timeToPgTime(now))
+}
+
+func (s *messageSuite) putString(dst []byte, value string) int {
+	copy(dst, []byte(value))
+	dst[len(value)] = byte(0)
+	return len(value) + 1
+}
+
+func TestBeginMessageSuite(t *testing.T) {
+	suite.Run(t, new(beginMessageSuite))
+}
+
+type beginMessageSuite struct {
+	messageSuite
+}
+
+func (s *beginMessageSuite) Test() {
+	finalLSN := s.newLSN()
+	commitTime, pgCommitTime := s.newTime()
+	xid := s.newXid()
+
+	msg := make([]byte, 1+8+8+4)
+	msg[0] = 'B'
+	bigEndian.PutUint64(msg[1:], uint64(finalLSN))
+	bigEndian.PutUint64(msg[9:], pgCommitTime)
+	bigEndian.PutUint32(msg[17:], xid)
+
+	m, err := Parse(msg)
+	s.NoError(err)
+	beginMsg, ok := m.(*BeginMessage)
+	s.True(ok)
+
+	expected := &BeginMessage{
+		FinalLSN:   finalLSN,
+		CommitTime: commitTime,
+		Xid:        xid,
+	}
+	expected.msgType = 'B'
+	s.Equal(expected, beginMsg)
+}
+
+func TestCommitMessage(t *testing.T) {
+	suite.Run(t, new(commitMessageSuite))
+}
+
+type commitMessageSuite struct {
+	messageSuite
+}
+
+func (s *commitMessageSuite) Test() {
+	flags := uint8(0)
+	commitLSN := s.newLSN()
+	transactionEndLSN := s.newLSN()
+	commitTime, pgCommitTime := s.newTime()
+
+	msg := make([]byte, 1+1+8+8+8)
+	msg[0] = 'C'
+	msg[1] = flags
+	bigEndian.PutUint64(msg[2:], uint64(commitLSN))
+	bigEndian.PutUint64(msg[10:], uint64(transactionEndLSN))
+	bigEndian.PutUint64(msg[18:], pgCommitTime)
+
+	m, err := Parse(msg)
+	s.NoError(err)
+	commitMsg, ok := m.(*CommitMessage)
+	s.True(ok)
+
+	expected := &CommitMessage{
+		Flags:             0,
+		CommitLSN:         commitLSN,
+		TransactionEndLSN: transactionEndLSN,
+		CommitTime:        commitTime,
+	}
+	expected.msgType = 'C'
+	s.Equal(expected, commitMsg)
+}
+
+func TestOriginMessage(t *testing.T) {
+	suite.Run(t, new(originMessageSuite))
+}
+
+type originMessageSuite struct {
+	messageSuite
+}
+
+func (s *originMessageSuite) Test() {
+	commitLSN := s.newLSN()
+	name := "someorigin"
+
+	msg := make([]byte, 1+8+len(name)+1) // 1 byte for \0
+	msg[0] = 'O'
+	bigEndian.PutUint64(msg[1:], uint64(commitLSN))
+	s.putString(msg[9:], name)
+
+	m, err := Parse(msg)
+	s.NoError(err)
+	originMsg, ok := m.(*OriginMessage)
+	s.True(ok)
+
+	expected := &OriginMessage{
+		CommitLSN: commitLSN,
+		Name:      name,
+	}
+	expected.msgType = 'O'
+	s.Equal(expected, originMsg)
+}
+
+func TestRelationMessageSuite(t *testing.T) {
+	suite.Run(t, new(relationMessageSuite))
+}
+
+type relationMessageSuite struct {
+	messageSuite
+}
+
+func (s *relationMessageSuite) Test() {
+	relationID := uint32(rand.Int31())
+	namespace := "public"
+	relationName := "table1"
+	col1 := "id"         // int8
+	col2 := "name"       // text
+	col3 := "created_at" // timestamptz
+
+	col1Length := 1 + len(col1) + 1 + 4 + 4
+	col2Length := 1 + len(col2) + 1 + 4 + 4
+	col3Length := 1 + len(col3) + 1 + 4 + 4
+
+	msg := make([]byte, 1+4+len(namespace)+1+len(relationName)+1+1+
+		2+col1Length+col2Length+col3Length)
+	msg[0] = 'R'
+	off := 1
+	bigEndian.PutUint32(msg[off:], relationID)
+	off += 4
+	off += s.putString(msg[off:], namespace)
+	off += s.putString(msg[off:], relationName)
+	msg[off] = 1
+	off++
+	bigEndian.PutUint16(msg[off:], 3)
+	off += 2
+
+	msg[off] = 1 // column id is key
+	off++
+	off += s.putString(msg[off:], col1)
+	bigEndian.PutUint32(msg[off:], 20) // int8
+	off += 4
+	bigEndian.PutUint32(msg[off:], 0)
+	off += 4
+
+	msg[off] = 0
+	off++
+	off += s.putString(msg[off:], col2)
+	bigEndian.PutUint32(msg[off:], 25) // text
+	off += 4
+	bigEndian.PutUint32(msg[off:], 0)
+	off += 4
+
+	msg[off] = 0
+	off++
+	off += s.putString(msg[off:], col3)
+	bigEndian.PutUint32(msg[off:], 1184) // timestamptz
+	off += 4
+	bigEndian.PutUint32(msg[off:], 0)
+	off += 4
+
+	m, err := Parse(msg)
+	s.NoError(err)
+	relationMsg, ok := m.(*RelationMessage)
+	s.True(ok)
+
+	expected := &RelationMessage{
+		RelationID:      relationID,
+		Namespace:       namespace,
+		RelationName:    relationName,
+		ReplicaIdentity: 1,
+		ColumnNum:       3,
+		Columns: []*RelationMessageColumn{
+			{
+				Flags:        1,
+				Name:         col1,
+				DataType:     20,
+				TypeModifier: 0,
+			},
+			{
+				Flags:        0,
+				Name:         col2,
+				DataType:     25,
+				TypeModifier: 0,
+			},
+			{
+				Flags:        0,
+				Name:         col3,
+				DataType:     1184,
+				TypeModifier: 0,
+			},
+		},
+	}
+	expected.msgType = 'R'
+	s.Equal(expected, relationMsg)
+}
+
+func TestTypeMessageSuite(t *testing.T) {
+	suite.Run(t, new(typeMessageSuite))
+}
+
+type typeMessageSuite struct {
+	messageSuite
+}
+
+func (s *typeMessageSuite) Test() {
+	dataType := uint32(1184) // timestamptz
+	namespace := "public"
+	name := "created_at"
+
+	msg := make([]byte, 1+4+len(namespace)+1+len(name)+1)
+	msg[0] = 'Y'
+	off := 1
+	bigEndian.PutUint32(msg[off:], dataType)
+	off += 4
+	off += s.putString(msg[off:], namespace)
+	s.putString(msg[off:], name)
+
+	m, err := Parse(msg)
+	s.NoError(err)
+	typeMsg, ok := m.(*TypeMessage)
+	s.True(ok)
+
+	expected := &TypeMessage{
+		DataType:  dataType,
+		Namespace: namespace,
+		Name:      name,
+	}
+	expected.msgType = 'Y'
+	s.Equal(expected, typeMsg)
+}


### PR DESCRIPTION
Support parsing logical replication message formats documented in this document:

https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html

Signed-off-by: diabloneo <diabloneo@gmail.com>