### PR TITLE
Use signed integer type for Relation message type modifier

### DIFF
--- a/message.go
+++ b/message.go
@@ -136,6 +136,11 @@ func (m *baseMessage) decodeUint64(src []byte) (uint64, int) {
 	return binary.BigEndian.Uint64(src), 8
 }
 
+func (m *baseMessage) decodeInt32(src []byte) (int32, int) {
+	asUint32, size := m.decodeUint32(src)
+	return int32(asUint32), size
+}
+
 // BeginMessage is a begin message.
 type BeginMessage struct {
 	baseMessage
@@ -234,7 +239,7 @@ type RelationMessageColumn struct {
 	DataType uint32
 
 	// TypeModifier is type modifier of the column (atttypmod).
-	TypeModifier uint32
+	TypeModifier int32
 }
 
 // RelationMessage is a relation message.
@@ -289,7 +294,7 @@ func (m *RelationMessage) Decode(src []byte) error {
 		column.DataType, used = m.decodeUint32(src[low:])
 		low += used
 
-		column.TypeModifier, used = m.decodeUint32(src[low:])
+		column.TypeModifier, used = m.decodeInt32(src[low:])
 		low += used
 
 		m.Columns = append(m.Columns, column)

--- a/message_test.go
+++ b/message_test.go
@@ -195,6 +195,7 @@ func (s *relationMessageSuite) Test() {
 	relationID := uint32(rand.Int31())
 	namespace := "public"
 	relationName := "table1"
+	noAtttypmod := int32(-1)
 	col1 := "id"         // int8
 	col2 := "name"       // text
 	col3 := "created_at" // timestamptz
@@ -221,7 +222,7 @@ func (s *relationMessageSuite) Test() {
 	off += s.putString(msg[off:], col1)
 	bigEndian.PutUint32(msg[off:], 20) // int8
 	off += 4
-	bigEndian.PutUint32(msg[off:], 0)
+	bigEndian.PutUint32(msg[off:], uint32(noAtttypmod))
 	off += 4
 
 	msg[off] = 0
@@ -229,7 +230,7 @@ func (s *relationMessageSuite) Test() {
 	off += s.putString(msg[off:], col2)
 	bigEndian.PutUint32(msg[off:], 25) // text
 	off += 4
-	bigEndian.PutUint32(msg[off:], 0)
+	bigEndian.PutUint32(msg[off:], uint32(noAtttypmod))
 	off += 4
 
 	msg[off] = 0
@@ -237,7 +238,7 @@ func (s *relationMessageSuite) Test() {
 	off += s.putString(msg[off:], col3)
 	bigEndian.PutUint32(msg[off:], 1184) // timestamptz
 	off += 4
-	bigEndian.PutUint32(msg[off:], 0)
+	bigEndian.PutUint32(msg[off:], uint32(noAtttypmod))
 	off += 4
 
 	m, err := Parse(msg)
@@ -256,19 +257,19 @@ func (s *relationMessageSuite) Test() {
 				Flags:        1,
 				Name:         col1,
 				DataType:     20,
-				TypeModifier: 0,
+				TypeModifier: -1,
 			},
 			{
 				Flags:        0,
 				Name:         col2,
 				DataType:     25,
-				TypeModifier: 0,
+				TypeModifier: -1,
 			},
 			{
 				Flags:        0,
 				Name:         col3,
 				DataType:     1184,
-				TypeModifier: 0,
+				TypeModifier: -1,
 			},
 		},
 	}


### PR DESCRIPTION
In the logical replication streaming protocol, the type modifier for the
Relation ('R') message is a signed 32-bit integer because -1 is commonly
used as a sentinel value for non-parameterized types, and this value
should be reflected in the decoded message.

Fixes #27 