### PR TITLE
Support PostgreSQL 10 and 15 in StartBaseBackup() and PostgreSQL >12 in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Create a user:
 create user pglogrepl with replication password 'secret';
 ```
 
+If you're using PostgreSQL 15 or newer grant access to the public schema, just for these tests:
+
+```
+grant all on schema public to pglogrepl;
+```
+
 Add a replication line to your pg_hba.conf:
 
 ```

--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -444,6 +444,8 @@ func getBaseBackupInfo(ctx context.Context, conn *pgconn.PgConn) (start LSN, tim
 		case *pgproto3.NoticeResponse:
 		case *pgproto3.CommandComplete:
 			return start, timelineID, nil
+		case *pgproto3.ErrorResponse:
+			return start, timelineID, errors.Errorf("error response sev=%q code=%q message=%q detail=%q position=%d", msg.Severity, msg.Code, msg.Message, msg.Detail, msg.Position)
 		default:
 			return start, timelineID, errors.Errorf("unexpected response: %t", msg)
 		}

--- a/pglogrepl_test.go
+++ b/pglogrepl_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -336,8 +337,10 @@ func TestBaseBackup(t *testing.T) {
 	require.NoError(t, err)
 	defer closeConn(t, conn)
 
+	// NOVERIFY_CHECKSUMS is only supported in PG11 and later
+	noVerifyChecksums := !strings.HasPrefix(conn.ParameterStatus("server_version"), "10.")
 	options := pglogrepl.BaseBackupOptions{
-		NoVerifyChecksums: true,
+		NoVerifyChecksums: noVerifyChecksums,
 		Progress:          true,
 		Label:             "pglogrepltest",
 		Fast:              true,
@@ -347,8 +350,8 @@ func TestBaseBackup(t *testing.T) {
 		TablespaceMap:     true,
 	}
 	startRes, err := pglogrepl.StartBaseBackup(context.Background(), conn, options)
-	require.GreaterOrEqual(t, startRes.TimelineID, int32(1))
 	require.NoError(t, err)
+	require.GreaterOrEqual(t, startRes.TimelineID, int32(1))
 
 	//Write the tablespaces
 	for i := 0; i < len(startRes.Tablespaces)+1; i++ {


### PR DESCRIPTION
This adds a server version parameter to BaseBackupOptions.sql() and uses it to generate a BASE_BACKUP request that will be understood by the server it's being sent to. That's a minor change for PostgreSQL 10, just silently ignoring NOVERIFY_CHECKSUMS, and a more significant change for PostgreSQL 15.

PostgreSQL >12 sends an additional keepalive message during the start of replication. This updates TestStartReplication() to ignore excess keepalives.

PostgreSQL 15 doesn't give access to the public schema by default; this adds a comment in the README about adding access to that schema for tests.

This passes all tests, including TestBaseBackup on Postgresql 10 through 15.

Closes #25, #43