### PR TITLE
fix DataRow message parsing in SendStandbyCopyDone

### DIFF
--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -696,9 +696,9 @@ func SendStandbyCopyDone(_ context.Context, conn *pgconn.PgConn) (cdr *CopyDoneR
 			// We are expecting just one row returned, with two columns timeline and LSN
 			// We should pay attention to RowDescription, but we'll take it on trust.
 			if len(m.Values) == 2 {
-				timeline, lerr := strconv.Atoi(string(m.Values[0][0]))
+				timeline, lerr := strconv.Atoi(string(m.Values[0]))
 				if lerr == nil {
-					lsn, lerr := ParseLSN(string(m.Values[0][1]))
+					lsn, lerr := ParseLSN(string(m.Values[1]))
 					if lerr == nil {
 						cdr.Timeline = int32(timeline)
 						cdr.LSN = lsn


### PR DESCRIPTION
Values of the message in a DataRow message is a slice of columns.

The tests do not cover receiving this message. It is quite difficult to test because it happens at a timeline change only, this would require the promote a standby as part of the test.

Closes #51 