### PR TITLE
Add support for logical decoding messages

### DIFF
--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	var pluginArguments []string
 	if outputPlugin == "pgoutput" {
-		pluginArguments = []string{"proto_version '1'", "publication_names 'pglogrepl_demo'"}
+		pluginArguments = []string{"proto_version '1'", "publication_names 'pglogrepl_demo'", "messages 'true'"}
 	} else if outputPlugin == "wal2json" {
 		pluginArguments = []string{"\"pretty-print\" 'true'"}
 	}
@@ -161,6 +161,10 @@ func main() {
 
 			case *pglogrepl.TypeMessage:
 			case *pglogrepl.OriginMessage:
+
+			case *pglogrepl.LogicalDecodingMessage:
+				log.Printf("Logical decoding message: %q, %q", logicalMsg.Prefix, logicalMsg.Content)
+
 			default:
 				log.Printf("Unknown message type in pgoutput stream: %T", logicalMsg)
 			}


### PR DESCRIPTION
This PR adds support for the logical decoding message type, as published by [`pg_logical_emit_message`](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-REPLICATION).

I followed the spec here:
https://www.postgresql.org/docs/devel/protocol-logicalrep-message-formats.html

Example message:

```
select pg_logical_emit_message(false, 'context', '{ "x": 124 }');
```

The motivation here is ultimately to support use-cases similar to those described in this post:
https://www.infoq.com/articles/wonders-of-postgres-logical-decoding-messages/