### PR TITLE
Add support of v2 replication protocol

### DIFF
--- a/example/pglogrepl_demo/README.md
+++ b/example/pglogrepl_demo/README.md
@@ -51,3 +51,14 @@ You should see output like the following from the `pglogrepl_demo` process.
 2019/08/22 20:05:15 Sent Standby status message
 2019/08/22 20:05:15 Primary Keepalive Message => ServerWALEnd: 3/A6693FF8 ServerTime: 2019-08-22 20:05:15.378933 -0500 CDT ReplyRequested: false
 ```
+
+## Notes on streaming
+
+Postgres since version 14 supports streaming large in-progress transactions via replication protocol.
+These transactions are now supported with StreamXXXMessage.
+To use this feature at least protocol version 2 must be used and 'streaming' parameter should be set to 'true' for 'pgoutput' plugin.
+
+Exactly when PG starts to stream transaction is determined by "logical_decoding_work_mem" configuration parameter.
+For testing purposes it can be set to the minimum value (64kB). Min value is not recommended for production use. 
+
+At the moment wal2json plugin doesn't support streaming.

--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -36,20 +36,23 @@ func main() {
 	log.Println("create publication pglogrepl_demo")
 
 	var pluginArguments []string
+	var v2 bool
 	if outputPlugin == "pgoutput" {
 		// streaming of large transactions is available since PG 14 (protocol version 2)
 		// we also need to set 'streaming' to 'true'
-		//pluginArguments = []string{
-		//	"proto_version '2'",
-		//	"publication_names 'pglogrepl_demo'",
-		//	"messages 'true'",
-		//	"streaming 'true'",
-		//}
 		pluginArguments = []string{
-			"proto_version '1'",
+			"proto_version '2'",
 			"publication_names 'pglogrepl_demo'",
 			"messages 'true'",
+			"streaming 'true'",
 		}
+		v2 = true
+		//uncomment for v1
+		//pluginArguments = []string{
+		//	"proto_version '1'",
+		//	"publication_names 'pglogrepl_demo'",
+		//	"messages 'true'",
+		//}
 	} else if outputPlugin == "wal2json" {
 		pluginArguments = []string{"\"pretty-print\" 'true'"}
 	}
@@ -77,7 +80,12 @@ func main() {
 	standbyMessageTimeout := time.Second * 10
 	nextStandbyMessageDeadline := time.Now().Add(standbyMessageTimeout)
 	relations := map[uint32]*pglogrepl.RelationMessage{}
+	relationsV2 := map[uint32]*pglogrepl.RelationMessageV2{}
 	typeMap := pgtype.NewMap()
+
+	// whenever we get StreamStartMessage we set inStream to true and then pass it to DecodeV2 function
+	// on StreamStopMessage we set it back to false
+	inStream := false
 
 	for {
 		if time.Now().After(nextStandbyMessageDeadline) {
@@ -115,7 +123,7 @@ func main() {
 			if err != nil {
 				log.Fatalln("ParsePrimaryKeepaliveMessage failed:", err)
 			}
-			log.Println("Primary Keepalive Message =>", "ServerWALEnd:", pkm.ServerWALEnd, "ServerTime:", pkm.ServerTime, "ReplyRequested:", pkm.ReplyRequested)
+			//log.Println("Primary Keepalive Message =>", "ServerWALEnd:", pkm.ServerWALEnd, "ServerTime:", pkm.ServerTime, "ReplyRequested:", pkm.ReplyRequested)
 
 			if pkm.ReplyRequested {
 				nextStandbyMessageDeadline = time.Time{}
@@ -126,71 +134,150 @@ func main() {
 			if err != nil {
 				log.Fatalln("ParseXLogData failed:", err)
 			}
+
 			log.Printf("XLogData => WALStart %s ServerWALEnd %s ServerTime %s WALData:\n%s\n", xld.WALStart, xld.ServerWALEnd, xld.ServerTime, hex.Dump(xld.WALData))
-			logicalMsg, err := pglogrepl.Parse(xld.WALData)
-			if err != nil {
-				log.Fatalf("Parse logical replication message: %s", err)
-			}
-			log.Printf("Receive a logical replication message: %s", logicalMsg.Type())
-			switch logicalMsg := logicalMsg.(type) {
-			case *pglogrepl.RelationMessage:
-				relations[logicalMsg.RelationID] = logicalMsg
-
-			case *pglogrepl.BeginMessage:
-				// Indicates the beginning of a group of changes in a transaction. This is only sent for committed transactions. You won't get any events from rolled back transactions.
-
-			case *pglogrepl.CommitMessage:
-
-			case *pglogrepl.InsertMessage:
-				rel, ok := relations[logicalMsg.RelationID]
-				if !ok {
-					log.Fatalf("unknown relation ID %d", logicalMsg.RelationID)
-				}
-				values := map[string]interface{}{}
-				for idx, col := range logicalMsg.Tuple.Columns {
-					colName := rel.Columns[idx].Name
-					switch col.DataType {
-					case 'n': // null
-						values[colName] = nil
-					case 'u': // unchanged toast
-						// This TOAST value was not changed. TOAST values are not stored in the tuple, and logical replication doesn't want to spend a disk read to fetch its value for you.
-					case 't': //text
-						val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType)
-						if err != nil {
-							log.Fatalln("error decoding column data:", err)
-						}
-						values[colName] = val
-					}
-				}
-				log.Printf("INSERT INTO %s.%s: %v", rel.Namespace, rel.RelationName, values)
-
-			case *pglogrepl.UpdateMessage:
-				// ...
-			case *pglogrepl.DeleteMessage:
-				// ...
-			case *pglogrepl.TruncateMessage:
-				// ...
-
-			case *pglogrepl.TypeMessage:
-			case *pglogrepl.OriginMessage:
-
-			case *pglogrepl.LogicalDecodingMessage:
-				log.Printf("Logical decoding message: %q, %q", logicalMsg.Prefix, logicalMsg.Content)
-
-			case *pglogrepl.StreamStartMessage:
-				log.Printf("Stream start message: xid %d, first segment? %d", logicalMsg.Xid, logicalMsg.FirstSegment)
-			case *pglogrepl.StreamStopMessage:
-				log.Printf("Stream stop message")
-			case *pglogrepl.StreamCommitMessage:
-				log.Printf("Stream commit message: xid %d", logicalMsg.Xid)
-			case *pglogrepl.StreamAbortMessage:
-				log.Printf("Stream abort message: xid %d", logicalMsg.Xid)
-			default:
-				log.Printf("Unknown message type in pgoutput stream: %T", logicalMsg)
+			if v2 {
+				processV2(xld.WALData, relationsV2, typeMap, &inStream)
+			} else {
+				processV1(xld.WALData, relations, typeMap)
 			}
 
 			clientXLogPos = xld.WALStart + pglogrepl.LSN(len(xld.WALData))
 		}
+	}
+}
+
+func processV2(walData []byte, relations map[uint32]*pglogrepl.RelationMessageV2, typeMap *pgtype.Map, inStream *bool) {
+	logicalMsg, err := pglogrepl.ParseV2(walData, *inStream)
+	if err != nil {
+		log.Fatalf("Parse logical replication message: %s", err)
+	}
+	log.Printf("Receive a logical replication message: %s", logicalMsg.Type())
+	switch logicalMsg := logicalMsg.(type) {
+	case *pglogrepl.RelationMessageV2:
+		relations[logicalMsg.RelationID] = logicalMsg
+
+	case *pglogrepl.BeginMessage:
+		// Indicates the beginning of a group of changes in a transaction. This is only sent for committed transactions. You won't get any events from rolled back transactions.
+
+	case *pglogrepl.CommitMessage:
+
+	case *pglogrepl.InsertMessageV2:
+		rel, ok := relations[logicalMsg.RelationID]
+		if !ok {
+			log.Fatalf("unknown relation ID %d", logicalMsg.RelationID)
+		}
+		values := map[string]interface{}{}
+		for idx, col := range logicalMsg.Tuple.Columns {
+			colName := rel.Columns[idx].Name
+			switch col.DataType {
+			case 'n': // null
+				values[colName] = nil
+			case 'u': // unchanged toast
+				// This TOAST value was not changed. TOAST values are not stored in the tuple, and logical replication doesn't want to spend a disk read to fetch its value for you.
+			case 't': //text
+				val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType)
+				if err != nil {
+					log.Fatalln("error decoding column data:", err)
+				}
+				values[colName] = val
+			}
+		}
+		log.Printf("insert for xid %d\n", logicalMsg.Xid)
+		log.Printf("INSERT INTO %s.%s: %v", rel.Namespace, rel.RelationName, values)
+
+	case *pglogrepl.UpdateMessageV2:
+		log.Printf("update for xid %d\n", logicalMsg.Xid)
+		// ...
+	case *pglogrepl.DeleteMessageV2:
+		log.Printf("delete for xid %d\n", logicalMsg.Xid)
+		// ...
+	case *pglogrepl.TruncateMessageV2:
+		log.Printf("truncate for xid %d\n", logicalMsg.Xid)
+		// ...
+
+	case *pglogrepl.TypeMessageV2:
+	case *pglogrepl.OriginMessage:
+
+	case *pglogrepl.LogicalDecodingMessageV2:
+		log.Printf("Logical decoding message: %q, %q, %d", logicalMsg.Prefix, logicalMsg.Content, logicalMsg.Xid)
+
+	case *pglogrepl.StreamStartMessageV2:
+		*inStream = true
+		log.Printf("Stream start message: xid %d, first segment? %d", logicalMsg.Xid, logicalMsg.FirstSegment)
+	case *pglogrepl.StreamStopMessageV2:
+		*inStream = false
+		log.Printf("Stream stop message")
+	case *pglogrepl.StreamCommitMessageV2:
+		log.Printf("Stream commit message: xid %d", logicalMsg.Xid)
+	case *pglogrepl.StreamAbortMessageV2:
+		log.Printf("Stream abort message: xid %d", logicalMsg.Xid)
+	default:
+		log.Printf("Unknown message type in pgoutput stream: %T", logicalMsg)
+	}
+}
+
+func processV1(walData []byte, relations map[uint32]*pglogrepl.RelationMessage, typeMap *pgtype.Map) {
+	logicalMsg, err := pglogrepl.Parse(walData)
+	if err != nil {
+		log.Fatalf("Parse logical replication message: %s", err)
+	}
+	log.Printf("Receive a logical replication message: %s", logicalMsg.Type())
+	switch logicalMsg := logicalMsg.(type) {
+	case *pglogrepl.RelationMessage:
+		relations[logicalMsg.RelationID] = logicalMsg
+
+	case *pglogrepl.BeginMessage:
+		// Indicates the beginning of a group of changes in a transaction. This is only sent for committed transactions. You won't get any events from rolled back transactions.
+
+	case *pglogrepl.CommitMessage:
+
+	case *pglogrepl.InsertMessage:
+		rel, ok := relations[logicalMsg.RelationID]
+		if !ok {
+			log.Fatalf("unknown relation ID %d", logicalMsg.RelationID)
+		}
+		values := map[string]interface{}{}
+		for idx, col := range logicalMsg.Tuple.Columns {
+			colName := rel.Columns[idx].Name
+			switch col.DataType {
+			case 'n': // null
+				values[colName] = nil
+			case 'u': // unchanged toast
+				// This TOAST value was not changed. TOAST values are not stored in the tuple, and logical replication doesn't want to spend a disk read to fetch its value for you.
+			case 't': //text
+				val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType)
+				if err != nil {
+					log.Fatalln("error decoding column data:", err)
+				}
+				values[colName] = val
+			}
+		}
+		log.Printf("INSERT INTO %s.%s: %v", rel.Namespace, rel.RelationName, values)
+
+	case *pglogrepl.UpdateMessage:
+		// ...
+	case *pglogrepl.DeleteMessage:
+		// ...
+	case *pglogrepl.TruncateMessage:
+		// ...
+
+	case *pglogrepl.TypeMessage:
+	case *pglogrepl.OriginMessage:
+
+	case *pglogrepl.LogicalDecodingMessage:
+		log.Printf("Logical decoding message: %q, %q", logicalMsg.Prefix, logicalMsg.Content)
+
+	case *pglogrepl.StreamStartMessageV2:
+		log.Printf("Stream start message: xid %d, first segment? %d", logicalMsg.Xid, logicalMsg.FirstSegment)
+	case *pglogrepl.StreamStopMessageV2:
+		log.Printf("Stream stop message")
+	case *pglogrepl.StreamCommitMessageV2:
+		log.Printf("Stream commit message: xid %d", logicalMsg.Xid)
+	case *pglogrepl.StreamAbortMessageV2:
+		log.Printf("Stream abort message: xid %d", logicalMsg.Xid)
+	default:
+		log.Printf("Unknown message type in pgoutput stream: %T", logicalMsg)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgx/v5 v5.0.3
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -25,11 +25,14 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/message.go
+++ b/message.go
@@ -671,122 +671,6 @@ func (m *LogicalDecodingMessage) Decode(src []byte) (err error) {
 	return nil
 }
 
-type StreamStartMessage struct {
-	baseMessage
-
-	Xid uint32
-	// A value of 1 indicates this is the first stream segment for this XID, 0 for any other stream segment
-	FirstSegment uint8
-}
-
-func (m *StreamStartMessage) Decode(src []byte) (err error) {
-	if len(src) < 5 {
-		return m.lengthError("StreamStartMessage", 5, len(src))
-	}
-
-	var low, used int
-	m.Xid, used = m.decodeUint32(src)
-	low += used
-	m.FirstSegment = src[low]
-
-	m.SetType(MessageTypeStreamStart)
-
-	return nil
-}
-
-type StreamStopMessage struct {
-	baseMessage
-}
-
-func (m *StreamStopMessage) Decode(_ []byte) (err error) {
-	// stream stop has no data
-	m.SetType(MessageTypeStreamStop)
-
-	return nil
-}
-
-type StreamCommitMessage struct {
-	baseMessage
-
-	Xid               uint32
-	Flags             uint8 // currently unused
-	CommitLSN         LSN
-	TransactionEndLSN LSN
-	CommitTime        time.Time
-}
-
-func (m *StreamCommitMessage) Decode(src []byte) (err error) {
-	if len(src) < 29 {
-		return m.lengthError("StreamCommitMessage", 29, len(src))
-	}
-	var low, used int
-	m.Xid, used = m.decodeUint32(src)
-	low += used
-	m.Flags = src[low]
-	low += 1
-	m.CommitLSN, used = m.decodeLSN(src[low:])
-	low += used
-	m.TransactionEndLSN, used = m.decodeLSN(src[low:])
-	low += used
-	m.CommitTime, _ = m.decodeTime(src[low:])
-
-	m.SetType(MessageTypeStreamCommit)
-
-	return nil
-}
-
-type StreamAbortMessage struct {
-	baseMessage
-
-	Xid    uint32
-	SubXid uint32
-}
-
-func (m *StreamAbortMessage) Decode(src []byte) (err error) {
-	if len(src) < 8 {
-		return m.lengthError("StreamAbortMessage", 29, len(src))
-	}
-
-	var low, used int
-	m.Xid, used = m.decodeUint32(src)
-	low += used
-	m.SubXid, _ = m.decodeUint32(src[low:])
-
-	m.SetType(MessageTypeStreamAbort)
-
-	return nil
-}
-
-// ParseV2 parse a logical replication message from protocol version #2
-// it accepts a slice of bytes read from PG and inStream parameter
-// inStream must be true when StreamStartMessage has been read
-// it must be false after StreamStopMessage has been read
-func ParseV2(data []byte, inStream bool) (m Message, err error) {
-	var decoder MessageDecoder
-	msgType := MessageType(data[0])
-
-	switch msgType {
-	case MessageTypeStreamStart:
-		decoder = new(StreamStartMessage)
-	case MessageTypeStreamStop:
-		decoder = new(StreamStopMessage)
-	case MessageTypeStreamCommit:
-		decoder = new(StreamCommitMessage)
-	case MessageTypeStreamAbort:
-		decoder = new(StreamAbortMessage)
-	default:
-		decoder = getCommonDecoder(msgType)
-	}
-
-	if decoder != nil {
-		if err = decoder.Decode(data[1:]); err != nil {
-			return nil, err
-		}
-	}
-
-	return decoder.(Message), nil
-}
-
 // Parse parse a logical replication message.
 func Parse(data []byte) (m Message, err error) {
 	var decoder MessageDecoder
@@ -809,12 +693,13 @@ func Parse(data []byte) (m Message, err error) {
 	default:
 		decoder = getCommonDecoder(msgType)
 	}
-	if decoder != nil {
-		if err = decoder.Decode(data[1:]); err != nil {
-			return nil, err
-		}
-	} else {
+
+	if decoder == nil {
 		return nil, errMsgNotSupported
+	}
+
+	if err = decoder.Decode(data[1:]); err != nil {
+		return nil, err
 	}
 
 	return decoder.(Message), nil

--- a/messageV2.go
+++ b/messageV2.go
@@ -1,0 +1,1 @@
+package pglogrepl

--- a/messageV2.go
+++ b/messageV2.go
@@ -1,1 +1,300 @@
 package pglogrepl
+
+import (
+	"encoding/binary"
+	"time"
+)
+
+type MessageDecoderV2 interface {
+	MessageDecoder
+	DecodeV2(src []byte, inStream bool) error
+}
+
+type StreamStartMessageV2 struct {
+	baseMessage
+
+	Xid uint32
+	// A value of 1 indicates this is the first stream segment for this XID, 0 for any other stream segment
+	FirstSegment uint8
+}
+
+func (m *StreamStartMessageV2) DecodeV2(src []byte, _ bool) (err error) {
+	if len(src) < 5 {
+		return m.lengthError("StreamStartMessageV2", 5, len(src))
+	}
+
+	var low, used int
+	m.Xid, used = m.decodeUint32(src)
+	low += used
+	m.FirstSegment = src[low]
+
+	m.SetType(MessageTypeStreamStart)
+
+	return nil
+}
+
+type StreamStopMessageV2 struct {
+	baseMessage
+}
+
+func (m *StreamStopMessageV2) DecodeV2(_ []byte, _ bool) (err error) {
+	// stream stop has no data
+	m.SetType(MessageTypeStreamStop)
+
+	return nil
+}
+
+type StreamCommitMessageV2 struct {
+	baseMessage
+
+	Xid               uint32
+	Flags             uint8 // currently unused
+	CommitLSN         LSN
+	TransactionEndLSN LSN
+	CommitTime        time.Time
+}
+
+func (m *StreamCommitMessageV2) DecodeV2(src []byte, _ bool) (err error) {
+	if len(src) < 29 {
+		return m.lengthError("StreamCommitMessageV2", 29, len(src))
+	}
+	var low, used int
+	m.Xid, used = m.decodeUint32(src)
+	low += used
+	m.Flags = src[low]
+	low += 1
+	m.CommitLSN, used = m.decodeLSN(src[low:])
+	low += used
+	m.TransactionEndLSN, used = m.decodeLSN(src[low:])
+	low += used
+	m.CommitTime, _ = m.decodeTime(src[low:])
+
+	m.SetType(MessageTypeStreamCommit)
+
+	return nil
+}
+
+type StreamAbortMessageV2 struct {
+	baseMessage
+
+	Xid    uint32
+	SubXid uint32
+}
+
+func (m *StreamAbortMessageV2) DecodeV2(src []byte, _ bool) (err error) {
+	if len(src) < 8 {
+		return m.lengthError("StreamAbortMessageV2", 8, len(src))
+	}
+
+	var low, used int
+	m.Xid, used = m.decodeUint32(src)
+	low += used
+	m.SubXid, _ = m.decodeUint32(src[low:])
+
+	m.SetType(MessageTypeStreamAbort)
+
+	return nil
+}
+
+// ParseV2 parse a logical replication message from protocol version #2
+// it accepts a slice of bytes read from PG and inStream parameter
+// inStream must be true when StreamStartMessage has been read
+// it must be false after StreamStopMessageV2 has been read
+func ParseV2(data []byte, inStream bool) (m Message, err error) {
+	var decoder MessageDecoder
+	msgType := MessageType(data[0])
+
+	switch msgType {
+	case MessageTypeStreamStart:
+		decoder = new(StreamStartMessageV2)
+	case MessageTypeStreamStop:
+		decoder = new(StreamStopMessageV2)
+	case MessageTypeStreamCommit:
+		decoder = new(StreamCommitMessageV2)
+	case MessageTypeStreamAbort:
+		decoder = new(StreamAbortMessageV2)
+	case MessageTypeMessage:
+		decoder = new(LogicalDecodingMessageV2)
+	case MessageTypeRelation:
+		decoder = new(RelationMessageV2)
+	case MessageTypeType:
+		decoder = new(TypeMessageV2)
+	case MessageTypeInsert:
+		decoder = new(InsertMessageV2)
+	case MessageTypeUpdate:
+		decoder = new(UpdateMessageV2)
+	case MessageTypeDelete:
+		decoder = new(DeleteMessageV2)
+	case MessageTypeTruncate:
+		decoder = new(TruncateMessageV2)
+	default:
+		decoder = getCommonDecoder(msgType)
+	}
+
+	if decoder == nil {
+		return nil, errMsgNotSupported
+	}
+
+	if v2, ok := decoder.(MessageDecoderV2); ok {
+		if err = v2.DecodeV2(data[1:], inStream); err != nil {
+			return nil, err
+		}
+	} else if err = decoder.Decode(data[1:]); err != nil {
+		return nil, err
+	}
+
+	return decoder.(Message), nil
+}
+
+type InStreamMessageV2WithXid struct {
+	Xid uint32
+}
+
+type LogicalDecodingMessageV2 struct {
+	LogicalDecodingMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *LogicalDecodingMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.LogicalDecodingMessage.Decode(src)
+	}
+
+	if len(src) < 18 {
+		return m.lengthError("LogicalDecodingMessage", 18, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.LogicalDecodingMessage.Decode(src)
+}
+
+type RelationMessageV2 struct {
+	RelationMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *RelationMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.RelationMessage.Decode(src)
+	}
+
+	if len(src) < 11 {
+		return m.lengthError("RelationMessageV2", 11, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.RelationMessage.Decode(src)
+}
+
+type TypeMessageV2 struct {
+	TypeMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *TypeMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.TypeMessage.Decode(src)
+	}
+
+	if len(src) < 10 {
+		return m.lengthError("TypeMessageV2", 10, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.TypeMessage.Decode(src)
+}
+
+type InsertMessageV2 struct {
+	InsertMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *InsertMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.InsertMessage.Decode(src)
+	}
+
+	if len(src) < 12 {
+		return m.lengthError("InsertMessageV2", 12, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.InsertMessage.Decode(src)
+}
+
+type UpdateMessageV2 struct {
+	UpdateMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *UpdateMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.UpdateMessage.Decode(src)
+	}
+
+	if len(src) < 10 {
+		return m.lengthError("UpdateMessageV2", 10, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.UpdateMessage.Decode(src)
+}
+
+type DeleteMessageV2 struct {
+	DeleteMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *DeleteMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.DeleteMessage.Decode(src)
+	}
+
+	if len(src) < 8 {
+		return m.lengthError("DeleteMessageV2", 8, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.DeleteMessage.Decode(src)
+}
+
+type TruncateMessageV2 struct {
+	TruncateMessage
+	InStreamMessageV2WithXid
+}
+
+func (m *TruncateMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
+	if !inStream {
+		return m.TruncateMessage.Decode(src)
+	}
+
+	if len(src) < 13 {
+		return m.lengthError("TruncateMessageV2", 13, len(src))
+	}
+
+	src = readXidAndAdvance(src, &m.InStreamMessageV2WithXid, inStream)
+
+	return m.TruncateMessage.Decode(src)
+}
+
+func readXidAndAdvance(src []byte, mXid *InStreamMessageV2WithXid, inStream bool) []byte {
+	var xid uint32
+	var used int
+
+	if inStream {
+		xid, used = decodeUint32(src)
+		mXid.Xid = xid
+	}
+
+	return src[used:]
+}
+
+func decodeUint32(src []byte) (uint32, int) {
+	return binary.BigEndian.Uint32(src), 4
+}

--- a/messageV2.go
+++ b/messageV2.go
@@ -11,6 +11,7 @@ type MessageDecoderV2 interface {
 	DecodeV2(src []byte, inStream bool) error
 }
 
+// StreamStartMessageV2 is a stream start message.
 type StreamStartMessageV2 struct {
 	baseMessage
 
@@ -19,6 +20,7 @@ type StreamStartMessageV2 struct {
 	FirstSegment uint8
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *StreamStartMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 	if len(src) < 5 {
 		return m.lengthError("StreamStartMessageV2", 5, len(src))
@@ -34,17 +36,20 @@ func (m *StreamStartMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 	return nil
 }
 
+// StreamStopMessageV2 is a stream stop message.
 type StreamStopMessageV2 struct {
 	baseMessage
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *StreamStopMessageV2) DecodeV2(_ []byte, _ bool) (err error) {
-	// stream stop has no data
+	// stream stop has no data.
 	m.SetType(MessageTypeStreamStop)
 
 	return nil
 }
 
+// StreamCommitMessageV2 is a stream commit message.
 type StreamCommitMessageV2 struct {
 	baseMessage
 
@@ -55,6 +60,7 @@ type StreamCommitMessageV2 struct {
 	CommitTime        time.Time
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *StreamCommitMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 	if len(src) < 29 {
 		return m.lengthError("StreamCommitMessageV2", 29, len(src))
@@ -75,6 +81,7 @@ func (m *StreamCommitMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 	return nil
 }
 
+// StreamAbortMessageV2 is a stream abort message.
 type StreamAbortMessageV2 struct {
 	baseMessage
 
@@ -83,6 +90,7 @@ type StreamAbortMessageV2 struct {
 	SubXid uint32
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *StreamAbortMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 	if len(src) < 8 {
 		return m.lengthError("StreamAbortMessageV2", 8, len(src))
@@ -148,15 +156,19 @@ func ParseV2(data []byte, inStream bool) (m Message, err error) {
 	return decoder.(Message), nil
 }
 
+// InStreamMessageV2WithXid is a V2 protocol message
 type InStreamMessageV2WithXid struct {
+	// Xid of the transaction (only present for streamed transactions).
 	Xid uint32
 }
 
+// LogicalDecodingMessageV2 is a logical decoding message.
 type LogicalDecodingMessageV2 struct {
 	LogicalDecodingMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *LogicalDecodingMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.LogicalDecodingMessage.Decode(src)
@@ -171,11 +183,13 @@ func (m *LogicalDecodingMessageV2) DecodeV2(src []byte, inStream bool) (err erro
 	return m.LogicalDecodingMessage.Decode(src)
 }
 
+// RelationMessageV2 is a relation message.
 type RelationMessageV2 struct {
 	RelationMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *RelationMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.RelationMessage.Decode(src)
@@ -190,11 +204,13 @@ func (m *RelationMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	return m.RelationMessage.Decode(src)
 }
 
+// TypeMessageV2 is a type message.
 type TypeMessageV2 struct {
 	TypeMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *TypeMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.TypeMessage.Decode(src)
@@ -209,11 +225,13 @@ func (m *TypeMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	return m.TypeMessage.Decode(src)
 }
 
+// InsertMessageV2 is an insert message.
 type InsertMessageV2 struct {
 	InsertMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *InsertMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.InsertMessage.Decode(src)
@@ -228,11 +246,13 @@ func (m *InsertMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	return m.InsertMessage.Decode(src)
 }
 
+// UpdateMessageV2 is an update message.
 type UpdateMessageV2 struct {
 	UpdateMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *UpdateMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.UpdateMessage.Decode(src)
@@ -247,11 +267,13 @@ func (m *UpdateMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	return m.UpdateMessage.Decode(src)
 }
 
+// DeleteMessageV2 is a delete message.
 type DeleteMessageV2 struct {
 	DeleteMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *DeleteMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.DeleteMessage.Decode(src)
@@ -266,11 +288,13 @@ func (m *DeleteMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	return m.DeleteMessage.Decode(src)
 }
 
+// TruncateMessageV2 is a truncate message.
 type TruncateMessageV2 struct {
 	TruncateMessage
 	InStreamMessageV2WithXid
 }
 
+// DecodeV2 decodes to message from V2 src.
 func (m *TruncateMessageV2) DecodeV2(src []byte, inStream bool) (err error) {
 	if !inStream {
 		return m.TruncateMessage.Decode(src)

--- a/messageV2.go
+++ b/messageV2.go
@@ -98,7 +98,7 @@ func (m *StreamAbortMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 
 // ParseV2 parse a logical replication message from protocol version #2
 // it accepts a slice of bytes read from PG and inStream parameter
-// inStream must be true when StreamStartMessage has been read
+// inStream must be true when StreamStartMessageV2 has been read
 // it must be false after StreamStopMessageV2 has been read
 func ParseV2(data []byte, inStream bool) (m Message, err error) {
 	var decoder MessageDecoder

--- a/messageV2.go
+++ b/messageV2.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// MessageDecoderV2 decodes message from V2 protocol into struct.
 type MessageDecoderV2 interface {
 	MessageDecoder
 	DecodeV2(src []byte, inStream bool) error
@@ -77,7 +78,8 @@ func (m *StreamCommitMessageV2) DecodeV2(src []byte, _ bool) (err error) {
 type StreamAbortMessageV2 struct {
 	baseMessage
 
-	Xid    uint32
+	Xid uint32
+	// Xid of the subtransaction (will be same as xid of the transaction for top-level transactions).
 	SubXid uint32
 }
 

--- a/messageV2_test.go
+++ b/messageV2_test.go
@@ -36,6 +36,20 @@ func (s *logicalDecodingMessageSuiteV2) Test() {
 	s.Equal(expectedV2, logicalDecodingMsg)
 }
 
+func (s *logicalDecodingMessageSuiteV2) TestNoStream() {
+	msg := make([]byte, 1+1+8+5+4+5)
+	msg[0] = 'M'
+	expected := s.putMessageTestData(msg[1:])
+	expected.msgType = MessageTypeMessage
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	logicalDecodingMsg, ok := m.(*LogicalDecodingMessageV2)
+	s.True(ok)
+
+	s.Equal(uint32(0), logicalDecodingMsg.Xid)
+	s.Equal(expected, &logicalDecodingMsg.LogicalDecodingMessage)
+}
+
 func TestStreamStartV2Suite(t *testing.T) {
 	suite.Run(t, new(streamStartSuite))
 }
@@ -187,6 +201,16 @@ func (s *relationMessageV2Suite) Test() {
 	s.Equal(expected, &relMsg.RelationMessage)
 }
 
+func (s *relationMessageV2Suite) TestNoStream() {
+	msg, expected := s.createRelationTestData()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	relMsg, ok := m.(*RelationMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), relMsg.Xid)
+	s.Equal(expected, &relMsg.RelationMessage)
+}
+
 func TestTypeMessageV2Suite(t *testing.T) {
 	suite.Run(t, new(typeMessageV2Suite))
 }
@@ -204,6 +228,16 @@ func (s *typeMessageV2Suite) Test() {
 	typeMsg, ok := m.(*TypeMessageV2)
 	s.True(ok)
 	s.Equal(xid, typeMsg.Xid)
+	s.Equal(expected, &typeMsg.TypeMessage)
+}
+
+func (s *typeMessageV2Suite) TestNoStream() {
+	msg, expected := s.createTypeTestData()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	typeMsg, ok := m.(*TypeMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), typeMsg.Xid)
 	s.Equal(expected, &typeMsg.TypeMessage)
 }
 
@@ -227,6 +261,17 @@ func (s *insertMessageV2Suite) Test() {
 	s.Equal(expected, &insertMsg.InsertMessage)
 }
 
+func (s *insertMessageV2Suite) TestNoStream() {
+	msg, expected := s.createInsertTestData()
+
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	insertMsg, ok := m.(*InsertMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), insertMsg.Xid)
+	s.Equal(expected, &insertMsg.InsertMessage)
+}
+
 func TestUpdateMessageV2Suite(t *testing.T) {
 	suite.Run(t, new(updateMessageV2Suite))
 }
@@ -247,6 +292,16 @@ func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeK() {
 	s.Equal(expected, &updateMsg.UpdateMessage)
 }
 
+func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeKNoStream() {
+	msg, expected := s.createUpdateTestDataTypeK()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
 func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeO() {
 	msg, expected := s.createUpdateTestDataTypeO()
 	msgV2, xid := s.insertXid(msg)
@@ -259,6 +314,16 @@ func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeO() {
 	s.Equal(expected, &updateMsg.UpdateMessage)
 }
 
+func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeONoStream() {
+	msg, expected := s.createUpdateTestDataTypeO()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
 func (s *updateMessageV2Suite) TestUpdateV2WithoutOldTuple() {
 	msg, expected := s.createUpdateTestDataWithoutOldTuple()
 	msgV2, xid := s.insertXid(msg)
@@ -268,6 +333,16 @@ func (s *updateMessageV2Suite) TestUpdateV2WithoutOldTuple() {
 	updateMsg, ok := m.(*UpdateMessageV2)
 	s.True(ok)
 	s.Equal(xid, updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
+func (s *updateMessageV2Suite) TestUpdateV2WithoutOldTupleNoStream() {
+	msg, expected := s.createUpdateTestDataWithoutOldTuple()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), updateMsg.Xid)
 	s.Equal(expected, &updateMsg.UpdateMessage)
 }
 
@@ -291,6 +366,16 @@ func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeK() {
 	s.Equal(expected, &deleteMsg.DeleteMessage)
 }
 
+func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeKNoStream() {
+	msg, expected := s.createDeleteTestDataTypeK()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	deleteMsg, ok := m.(*DeleteMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), deleteMsg.Xid)
+	s.Equal(expected, &deleteMsg.DeleteMessage)
+}
+
 func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeO() {
 	msg, expected := s.createDeleteTestDataTypeO()
 	msgV2, xid := s.insertXid(msg)
@@ -300,6 +385,16 @@ func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeO() {
 	deleteMsg, ok := m.(*DeleteMessageV2)
 	s.True(ok)
 	s.Equal(xid, deleteMsg.Xid)
+	s.Equal(expected, &deleteMsg.DeleteMessage)
+}
+
+func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeONoStream() {
+	msg, expected := s.createDeleteTestDataTypeO()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	deleteMsg, ok := m.(*DeleteMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), deleteMsg.Xid)
 	s.Equal(expected, &deleteMsg.DeleteMessage)
 }
 
@@ -320,5 +415,15 @@ func (s *truncateMessageSuiteV2) Test() {
 	truncateMsg, ok := m.(*TruncateMessageV2)
 	s.True(ok)
 	s.Equal(xid, truncateMsg.Xid)
+	s.Equal(expected, &truncateMsg.TruncateMessage)
+}
+
+func (s *truncateMessageSuiteV2) TestNoStream() {
+	msg, expected := s.createTruncateTestData()
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	truncateMsg, ok := m.(*TruncateMessageV2)
+	s.True(ok)
+	s.Equal(uint32(0), truncateMsg.Xid)
 	s.Equal(expected, &truncateMsg.TruncateMessage)
 }

--- a/messageV2_test.go
+++ b/messageV2_test.go
@@ -1,0 +1,369 @@
+package pglogrepl
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+func putMessageTestData(msg []byte, s *messageSuite) *LogicalDecodingMessage {
+	// transaction flag
+	msg[0] = 1
+	off := 1
+
+	lsn := s.newLSN()
+	bigEndian.PutUint64(msg[off:], uint64(lsn))
+	off += 8
+
+	off += s.putString(msg[off:], "test")
+
+	content := "hello"
+
+	bigEndian.PutUint32(msg[off:], uint32(len(content)))
+	off += 4
+
+	for i := 0; i < len(content); i++ {
+		msg[off] = content[i]
+		off++
+	}
+	return &LogicalDecodingMessage{
+		Transactional: true,
+		LSN:           lsn,
+		Prefix:        "test",
+		Content:       []byte("hello"),
+	}
+}
+
+func (s *messageSuite) assertV1NotSupported(msg []byte) {
+	_, err := Parse(msg)
+	s.Error(err)
+	s.True(errors.Is(err, errMsgNotSupported))
+}
+
+func TestLogicalDecodingMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(logicalDecodingMessageSuiteV2))
+}
+
+type logicalDecodingMessageSuiteV2 struct {
+	messageSuite
+}
+
+func (s *logicalDecodingMessageSuiteV2) Test() {
+	msg := make([]byte, 1+4+1+8+5+4+5)
+	msg[0] = 'M'
+	xid := s.newXid()
+	bigEndian.PutUint32(msg[1:], xid)
+
+	expected := putMessageTestData(msg[5:], &s.messageSuite)
+
+	expectedV2 := &LogicalDecodingMessageV2{
+		LogicalDecodingMessage:   *expected,
+		InStreamMessageV2WithXid: InStreamMessageV2WithXid{Xid: xid},
+	}
+	expectedV2.msgType = MessageTypeMessage
+
+	m, err := ParseV2(msg, true)
+	s.NoError(err)
+	logicalDecodingMsg, ok := m.(*LogicalDecodingMessageV2)
+	s.True(ok)
+
+	s.Equal(expectedV2, logicalDecodingMsg)
+}
+
+func TestStreamStartV2Suite(t *testing.T) {
+	suite.Run(t, new(streamStartSuite))
+}
+
+type streamStartSuite struct {
+	messageSuite
+}
+
+func (s *streamStartSuite) Test() {
+	msg := make([]byte, 1+4+1)
+	msg[0] = 'S'
+	xid := s.newXid()
+	firstSeg := byte(1)
+	bigEndian.PutUint32(msg[1:], xid)
+	msg[5] = firstSeg
+
+	expected := &StreamStartMessageV2{
+		Xid:          xid,
+		FirstSegment: firstSeg,
+	}
+	expected.msgType = MessageTypeStreamStart
+	s.assertV1NotSupported(msg)
+
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	startMsg, ok := m.(*StreamStartMessageV2)
+	s.True(ok)
+
+	s.Equal(expected, startMsg)
+}
+
+func TestStreamStopV2Suite(t *testing.T) {
+	suite.Run(t, new(streamStopSuite))
+}
+
+type streamStopSuite struct {
+	messageSuite
+}
+
+func (s *streamStopSuite) Test() {
+	msg := make([]byte, 1)
+	msg[0] = 'E'
+
+	expected := &StreamStopMessageV2{}
+	expected.msgType = MessageTypeStreamStop
+
+	s.assertV1NotSupported(msg)
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	stopMsg, ok := m.(*StreamStopMessageV2)
+	s.True(ok)
+
+	s.Equal(expected, stopMsg)
+}
+
+func TestStreamCommitV2Suite(t *testing.T) {
+	suite.Run(t, new(streamCommitSuite))
+}
+
+type streamCommitSuite struct {
+	messageSuite
+}
+
+func (s *streamCommitSuite) Test() {
+	msg := make([]byte, 1+4+1+8+8+8)
+	xid := s.newXid()
+	flags := uint8(0)
+	commitLSN := s.newLSN()
+	transactionEndLSN := s.newLSN()
+	commitTime, pgCommitTime := s.newTime()
+
+	msg[0] = 'c'
+	bigEndian.PutUint32(msg[1:], xid)
+	fmt.Printf("%+v\n", msg)
+	msg[5] = flags
+	bigEndian.PutUint64(msg[6:], uint64(commitLSN))
+	bigEndian.PutUint64(msg[14:], uint64(transactionEndLSN))
+	bigEndian.PutUint64(msg[22:], pgCommitTime)
+
+	expected := &StreamCommitMessageV2{
+		Xid:               xid,
+		Flags:             flags,
+		CommitLSN:         commitLSN,
+		TransactionEndLSN: transactionEndLSN,
+		CommitTime:        commitTime,
+	}
+	expected.msgType = MessageTypeStreamCommit
+
+	s.assertV1NotSupported(msg)
+
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	streamCommitMsg, ok := m.(*StreamCommitMessageV2)
+	s.True(ok)
+	s.Equal(expected, streamCommitMsg)
+}
+
+func TestStreamAbortV2Suite(t *testing.T) {
+	suite.Run(t, new(streamAbortSuite))
+}
+
+type streamAbortSuite struct {
+	messageSuite
+}
+
+func (s *streamAbortSuite) Test() {
+	msg := make([]byte, 1+4+4)
+
+	xid := s.newXid()
+	subXid := s.newXid()
+
+	msg[0] = 'A'
+	bigEndian.PutUint32(msg[1:], xid)
+	bigEndian.PutUint32(msg[5:], subXid)
+
+	expected := &StreamAbortMessageV2{
+		Xid:    xid,
+		SubXid: subXid,
+	}
+	expected.msgType = MessageTypeStreamAbort
+
+	s.assertV1NotSupported(msg)
+
+	m, err := ParseV2(msg, false)
+	s.NoError(err)
+	streamAbortMsg, ok := m.(*StreamAbortMessageV2)
+	s.True(ok)
+	s.Equal(expected, streamAbortMsg)
+}
+
+func TestRelationMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(relationMessageV2Suite))
+}
+
+type relationMessageV2Suite struct {
+	messageSuite
+}
+
+func (s *relationMessageV2Suite) Test() {
+	msg, expected := s.createRelationTestData()
+
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	relMsg, ok := m.(*RelationMessageV2)
+	s.True(ok)
+	s.Equal(xid, relMsg.Xid)
+	s.Equal(expected, &relMsg.RelationMessage)
+}
+
+func TestTypeMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(typeMessageV2Suite))
+}
+
+type typeMessageV2Suite struct {
+	messageSuite
+}
+
+func (s *typeMessageV2Suite) Test() {
+	msg, expected := s.createTypeTestData()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	typeMsg, ok := m.(*TypeMessageV2)
+	s.True(ok)
+	s.Equal(xid, typeMsg.Xid)
+	s.Equal(expected, &typeMsg.TypeMessage)
+}
+
+func TestInsertMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(insertMessageV2Suite))
+}
+
+type insertMessageV2Suite struct {
+	messageSuite
+}
+
+func (s *insertMessageV2Suite) Test() {
+	msg, expected := s.createInsertTestData()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	insertMsg, ok := m.(*InsertMessageV2)
+	s.True(ok)
+	s.Equal(xid, insertMsg.Xid)
+	s.Equal(expected, &insertMsg.InsertMessage)
+}
+
+func TestUpdateMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(updateMessageV2Suite))
+}
+
+type updateMessageV2Suite struct {
+	messageSuite
+}
+
+func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeK() {
+	msg, expected := s.createUpdateTestDataTypeK()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(xid, updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
+func (s *updateMessageV2Suite) TestUpdateV2WithOldTupleTypeO() {
+	msg, expected := s.createUpdateTestDataTypeO()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(xid, updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
+func (s *updateMessageV2Suite) TestUpdateV2WithoutOldTuple() {
+	msg, expected := s.createUpdateTestDataWithoutOldTuple()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	updateMsg, ok := m.(*UpdateMessageV2)
+	s.True(ok)
+	s.Equal(xid, updateMsg.Xid)
+	s.Equal(expected, &updateMsg.UpdateMessage)
+}
+
+func TestDeleteMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(deleteMessageV2Suite))
+}
+
+type deleteMessageV2Suite struct {
+	messageSuite
+}
+
+func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeK() {
+	msg, expected := s.createDeleteTestDataTypeK()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	deleteMsg, ok := m.(*DeleteMessageV2)
+	s.True(ok)
+	s.Equal(xid, deleteMsg.Xid)
+	s.Equal(expected, &deleteMsg.DeleteMessage)
+}
+
+func (s *deleteMessageV2Suite) TestV2WithOldTupleTypeO() {
+	msg, expected := s.createDeleteTestDataTypeO()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	deleteMsg, ok := m.(*DeleteMessageV2)
+	s.True(ok)
+	s.Equal(xid, deleteMsg.Xid)
+	s.Equal(expected, &deleteMsg.DeleteMessage)
+}
+
+func TestTruncateMessageV2Suite(t *testing.T) {
+	suite.Run(t, new(truncateMessageSuiteV2))
+}
+
+type truncateMessageSuiteV2 struct {
+	messageSuite
+}
+
+func (s *truncateMessageSuiteV2) Test() {
+	msg, expected := s.createTruncateTestData()
+	msgV2, xid := s.insertXid(msg)
+
+	m, err := ParseV2(msgV2, true)
+	s.NoError(err)
+	truncateMsg, ok := m.(*TruncateMessageV2)
+	s.True(ok)
+	s.Equal(xid, truncateMsg.Xid)
+	s.Equal(expected, &truncateMsg.TruncateMessage)
+}
+
+func (s *messageSuite) insertXid(msg []byte) ([]byte, uint32) {
+	msgV2 := make([]byte, 4+len(msg))
+	msgV2[0] = msg[0]
+	xid := s.newXid()
+	bigEndian.PutUint32(msgV2[1:], xid)
+	copy(msgV2[5:], msg[1:])
+
+	return msgV2, xid
+}

--- a/pglogrepl_test.go
+++ b/pglogrepl_test.go
@@ -359,7 +359,7 @@ func TestBaseBackup(t *testing.T) {
 
 	//Write the tablespaces
 	for i := 0; i < len(startRes.Tablespaces)+1; i++ {
-		f, err := os.Create(fmt.Sprintf("/tmp/pglogrepl_test_tbs_%d.tar", i))
+		f, err := os.CreateTemp("", fmt.Sprintf("pglogrepl_test_tbs_%d.tar", i))
 		require.NoError(t, err)
 		err = pglogrepl.NextTableSpace(context.Background(), conn)
 		var message pgproto3.BackendMessage


### PR DESCRIPTION
Postgres since version 14 supports streaming large in-progress transactions via replication connection. This PR adds support of new messages (Stream Start/Stop/Commit/Abort) as well as updated V2 messages. 
Some messages (e.g. Insert/Update/Delete) have additional field (xid) when being streamed via V2 protocol. I addressed this by creating new structs *V2 (InsertMessageV2, etc.) and adding function ParseV2(data []byte, inStream bool).
I also updated sample application.
I took Information about message format from here:
https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html