### PR TITLE
fix: finish basebackup

### DIFF
--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -569,12 +569,10 @@ func FinishBaseBackup(ctx context.Context, conn *pgconn.PgConn) (result BaseBack
 	if err != nil {
 		return result, err
 	}
-	result.Tablespaces, err = getTableSpaceInfo(ctx, conn)
-	if err != nil {
-		return result, err
-	}
-	_, err = SendStandbyCopyDone(context.Background(), conn)
-	return result, err
+
+	// no tablespace infos are received here, only consume command complete response.
+	_, err = getTableSpaceInfo(ctx, conn)
+	return
 }
 
 type PrimaryKeepaliveMessage struct {

--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -571,7 +571,7 @@ func FinishBaseBackup(ctx context.Context, conn *pgconn.PgConn) (result BaseBack
 	}
 
 	// Base_Backup done, server send a command complete response from pg13
-	vmaj, err := getMajorVersion(conn)
+	vmaj, err := serverMajorVersion(conn)
 	if err != nil {
 		return
 	}
@@ -602,24 +602,6 @@ func FinishBaseBackup(ctx context.Context, conn *pgconn.PgConn) (result BaseBack
 		return
 	}
 	return
-}
-
-func getMajorVersion(conn *pgconn.PgConn) (int, error) {
-	sversion := conn.ParameterStatus("server_version")
-	if len(sversion) == 0 {
-		return 0, fmt.Errorf("no server_version")
-	}
-	var vmaj, vmin, vrev int
-	cnt, err := fmt.Sscanf(sversion, "%d.%d.%d", &vmaj, &vmin, &vrev)
-	if err != nil {
-		return 0, err
-	}
-	switch cnt {
-	case 1, 2, 3:
-		return vmaj, nil
-	default:
-	}
-	return 0, fmt.Errorf("unknown server version")
 }
 
 type PrimaryKeepaliveMessage struct {


### PR DESCRIPTION
At the end of BASE_BACKUP, the server only send a record which contains a finish lsn and tli and a command complete response.