### PR TITLE
Fix clientXLogPos handling in pglogrepl_demo

### DIFF
--- a/example/pglogrepl_demo/main.go
+++ b/example/pglogrepl_demo/main.go
@@ -125,7 +125,9 @@ func main() {
 				log.Fatalln("ParsePrimaryKeepaliveMessage failed:", err)
 			}
 			log.Println("Primary Keepalive Message =>", "ServerWALEnd:", pkm.ServerWALEnd, "ServerTime:", pkm.ServerTime, "ReplyRequested:", pkm.ReplyRequested)
-
+			if pkm.ServerWALEnd > clientXLogPos {
+				clientXLogPos = pkm.ServerWALEnd
+			}
 			if pkm.ReplyRequested {
 				nextStandbyMessageDeadline = time.Time{}
 			}
@@ -147,7 +149,9 @@ func main() {
 				}
 			}
 
-			clientXLogPos = xld.WALStart + pglogrepl.LSN(len(xld.WALData))
+			if xld.WALStart > clientXLogPos {
+				clientXLogPos = xld.WALStart
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR changes the handling of `clientXLogPos` to match the one from Postgres' own `pg_recvlogical`:
- keepalive messages should bump the position too, as they're only sent (from what I can tell) after any xlogdata message;
- both the WALStart and the ServerWALEnd in logical xlogdata messages represent the position that should be reported back, and adding the length of the post-decoding data to it is meaningless;
- relation messages have a position of zero, and in general we should match the `pg_recvlogical` behavior of only increasing the local position.