### PR TITLE
Handle more than 4 result columns from IDENTIFY_SYSTEM

### DIFF
--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -247,8 +247,8 @@ func ParseCreateReplicationSlot(mrr *pgconn.MultiResultReader) (CreateReplicatio
 	}
 
 	row := result.Rows[0]
-	if len(row) != 4 {
-		return crsr, fmt.Errorf("expected 4 result columns, got %d", len(row))
+	if len(row) < 4 {
+		return crsr, fmt.Errorf("expected at least 4 result columns, got %d", len(row))
 	}
 
 	crsr.SlotName = string(row[0])


### PR DESCRIPTION
Hey there 👋 

I ran into the following error when using `pglogrepl.IdentifySystem` on [Alloy DB](https://cloud.google.com/products/alloydb):

```
2025/03/28 16:00:31 ERROR service process failed err="identify system: cannot identify system: expected 4 result columns, got 5"
```

It turns out Alloy DB returns an extra column named `thtoken`. I'm not sure if the value is sensitive so I've blurred it out, but here's what the result looks like using `psql`:

![CleanShot 2025-03-28 at 12 29 47@2x](https://github.com/user-attachments/assets/ae9bc2ac-3e09-4649-8886-3c887e65ec74)

It looks like the columns are returned in the order `pglogrepl.IdentifySystem` is expecting, so this PR makes it check if there's at least 4 result columns rather than requiring there be 4 columns. I've been running this change in production for a few hours now and it looks to have fixed the issue.
