### PR TITLE
Revert "Handle more than 4 result columns from IDENTIFY_SYSTEM"

### DIFF
--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -247,8 +247,8 @@ func ParseCreateReplicationSlot(mrr *pgconn.MultiResultReader) (CreateReplicatio
 	}
 
 	row := result.Rows[0]
-	if len(row) < 4 {
-		return crsr, fmt.Errorf("expected at least 4 result columns, got %d", len(row))
+	if len(row) != 4 {
+		return crsr, fmt.Errorf("expected 4 result columns, got %d", len(row))
 	}
 
 	crsr.SlotName = string(row[0])

--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -139,8 +139,8 @@ func ParseIdentifySystem(mrr *pgconn.MultiResultReader) (IdentifySystemResult, e
 	}
 
 	row := result.Rows[0]
-	if len(row) != 4 {
-		return isr, fmt.Errorf("expected 4 result columns, got %d", len(row))
+	if len(row) < 4 {
+		return isr, fmt.Errorf("expected at least 4 result columns, got %d", len(row))
 	}
 
 	isr.SystemID = string(row[0])


### PR DESCRIPTION
I'm sorry, this is a follow up to #73 --  I accidentally made `ParseCreateReplicationSlot` handle more than 4 result columns rather than `ParseIdentifySystem` 🤦 

This PR reverts my original commit in #73 and makes the actual change I meant to make.