### PR TITLE
Fix SendStandbyCopyDone(), panic when promote 

### DIFF
--- a/pglogrepl.go
+++ b/pglogrepl.go
@@ -748,12 +748,14 @@ type CopyDoneResult struct {
 // SendStandbyCopyDone sends a StandbyCopyDone to the PostgreSQL server
 // to confirm ending the copy-both mode.
 func SendStandbyCopyDone(_ context.Context, conn *pgconn.PgConn) (cdr *CopyDoneResult, err error) {
+	cdr = &CopyDoneResult{}
+
 	// I am suspicious that this is wildly wrong, but I'm pretty sure the previous
 	// code was wildly wrong too -- wttw <steve@blighty.com>
 	conn.Frontend().Send(&pgproto3.CopyDone{})
 	err = conn.Frontend().Flush()
 	if err != nil {
-		return
+		return cdr, err
 	}
 
 	for {


### PR DESCRIPTION
When receiving *pgproto3.DataRow: getting panic: "panic: runtime error: invalid memory address or nil pointer dereference". This patch will fix it.

In this place cdr is uninitialized when populated with lsn and tli:
```
case *pgproto3.DataRow:
	if len(m.Values) == 2 {
		timeline, lerr := strconv.Atoi(string(m.Values[0]))
		if lerr == nil {
			lsn, lerr := pglogrepl.ParseLSN(string(m.Values[1]))
			if lerr == nil {
				cdr.Timeline = int32(timeline)
				cdr.LSN = lsn
			}
		}
	}
```